### PR TITLE
feat(provider): implementa CRUD de proveedores

### DIFF
--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -12,6 +12,8 @@ import {
   UserAdminPage,
   CreateUserPage,
   EditUserPage,
+  CreateProviderPage,
+  EditProviderPage
 } from '@app/lazy';
 import { Error404 } from '@/shared/components/Error404';
 import { Route, Routes } from 'react-router';
@@ -43,7 +45,12 @@ export default function Router() {
         <Route path='/configuration' element={<ConfigurationPage />} />
         <Route path='/entities'>
           <Route path='clients' element={<ClientPage />} />
-          <Route path='suppliers' element={<ProviderPage />} />
+          {/* <Route path='suppliers' element={<ProviderPage />} /> */}
+          <Route path='suppliers'>
+            <Route index element={<ProviderPage />} />
+            <Route path='create' element={<CreateProviderPage />} />
+            <Route path='edit/:cuit' element={<EditProviderPage />} />
+          </Route>
           <Route path='employees' element={<EmployeePage />} />
         </Route>
         <Route path='/box' element={<BoxPage />} />

--- a/src/app/lazy.ts
+++ b/src/app/lazy.ts
@@ -22,6 +22,12 @@ export const ClientPage = lazy(
 export const ProviderPage = lazy(
   () => import('@/features/provider/pages/ProviderPage')
 );
+export const CreateProviderPage = lazy(
+  () => import('@/features/provider/pages/CreateProviderPage')
+);
+export const EditProviderPage = lazy(
+  () => import('@/features/provider/pages/EditProviderPage')
+);
 export const EmployeePage = lazy(
   () => import('@/features/employee/pages/EmployeePage')
 );

--- a/src/features/provider/api/service.ts
+++ b/src/features/provider/api/service.ts
@@ -1,0 +1,48 @@
+import AxiosClient from "@app/axios"; 
+
+import {
+	GetProvidersResponse,
+	CreateProviderRequest,
+	CreateProviderResponse,
+	GetProviderRequest,
+	UpdateProviderRequest,
+	UpdateProviderResponse,
+	DeleteProviderResponse
+} from '@features/provider/types';
+
+export const getProviders = async (
+	data: GetProviderRequest
+): Promise<GetProvidersResponse> => {
+	const response = await AxiosClient.get<GetProvidersResponse>(
+		`/api/v1/providers?pageIndex=${data.pageIndex}&pageSize=${data.pageSize}`
+	);
+	return response
+}
+
+export const createProvider = async (
+	data: CreateProviderRequest
+): Promise<CreateProviderResponse> => {
+	const response = await AxiosClient.post<CreateProviderResponse>(
+		`/api/v1/providers`,
+		data
+	);
+	return response;
+}
+
+export const updateProvider = async (
+	providerDni: number,
+	data: UpdateProviderRequest
+): Promise<UpdateProviderResponse> => {
+	const response = await AxiosClient.put<UpdateProviderResponse>(
+		`/api/v1/providers/${providerDni}`,
+		data
+	);
+	return response;
+}
+
+export const deleteProvider = async (data: number): Promise<DeleteProviderResponse> => {
+	const response = await AxiosClient.delete<DeleteProviderResponse>(
+		`/api/v1/providers/${data}`
+	);
+	return response;
+}

--- a/src/features/provider/components/CreateProviderActions.tsx
+++ b/src/features/provider/components/CreateProviderActions.tsx
@@ -1,0 +1,71 @@
+import { Box, Button, Typography } from '@mui/material';
+import { LoadingButton } from '@/shared/components/LoadingButton';
+
+interface CreateProviderActionsProps {
+    onCancel: () => void;
+    isLoading: boolean;
+    isValid: boolean;
+}
+
+export default function CreateProviderActions({
+    onCancel,
+    isLoading,
+    isValid,
+}: CreateProviderActionsProps) {
+    return (
+    <>
+      <Typography
+        variant='caption'
+        color='text.secondary'
+        sx={{
+          gridColumn: '1 / -1',
+          mt: 1,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.5,
+        }}
+      >
+        <Box component='span' sx={{ color: 'error.main' }}>
+          *
+        </Box>
+        Campos obligatorios
+      </Typography>
+
+      <Box
+        sx={{
+          gridColumn: '1 / -1',
+          display: 'flex',
+          gap: 2,
+          justifyContent: 'flex-end',
+          mt: 2,
+        }}
+      >
+        <Button
+          variant='outlined'
+          onClick={onCancel}
+          disabled={isLoading}
+          sx={{
+            borderRadius: 2,
+            textTransform: 'none',
+            fontWeight: 600,
+          }}
+        >
+          Cancelar
+        </Button>
+        <LoadingButton
+          type='submit'
+          variant='contained'
+          loading={isLoading}
+          disabled={!isValid}
+          sx={{
+            borderRadius: 2,
+            textTransform: 'none',
+            fontWeight: 600,
+          }}
+        >
+          Crear Proveedor
+        </LoadingButton>
+      </Box>
+    </>
+  );
+}

--- a/src/features/provider/components/CreateProviderFormFields.tsx
+++ b/src/features/provider/components/CreateProviderFormFields.tsx
@@ -1,0 +1,22 @@
+import { Control } from "react-hook-form";
+import { FormTextField } from "@/shared/components/FormTextField";
+import { CreateProviderFormData } from "@/features/provider/schemas/createProviderSchema";
+
+interface CreateProviderFormFieldsProps {
+    control: Control<CreateProviderFormData>;
+}
+
+export default function CreateProviderFormFields({
+  control,
+}: CreateProviderFormFieldsProps) {
+  return (
+    <>
+      <FormTextField name='cuit' control={control} label='CUIT *' type='number' />
+
+      <FormTextField name='firstName' control={control} label='Nombre *' />
+
+      <FormTextField name='address' control={control} label='Dirección' />
+      <FormTextField name='description' control={control} label='Descripción' />
+    </>
+  );
+}

--- a/src/features/provider/components/CreateProviderHeader.tsx
+++ b/src/features/provider/components/CreateProviderHeader.tsx
@@ -1,0 +1,34 @@
+import { Box, Typography, IconButton } from '@mui/material';
+import { ArrowBack, PersonAdd } from '@mui/icons-material';
+
+interface CreateProviderHeaderProps {
+  onBack: () => void;
+}
+
+export default function CreateProviderHeader({ onBack }: CreateProviderHeaderProps) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 2,
+        mb: 3,
+      }}
+    >
+      <IconButton
+        onClick={onBack}
+        sx={{
+          bgcolor: 'background.paper',
+          border: 1,
+          borderColor: 'divider',
+        }}
+      >
+        <ArrowBack />
+      </IconButton>
+      <PersonAdd sx={{ fontSize: 32, color: 'primary.main' }} />
+      <Typography variant='h4' fontWeight={600}>
+        Crear Nuevo Proveedor
+      </Typography>
+    </Box>
+  );
+}

--- a/src/features/provider/components/EditProviderActions.tsx
+++ b/src/features/provider/components/EditProviderActions.tsx
@@ -1,0 +1,71 @@
+import { Box, Button, Typography } from '@mui/material';
+import { LoadingButton } from '@/shared/components/LoadingButton';
+
+interface EditProviderActionsProps {
+  onCancel: () => void;
+  isLoading: boolean;
+  isValid: boolean;
+}
+
+export default function EditProviderActions({
+  onCancel,
+  isLoading,
+  isValid,
+}: EditProviderActionsProps) {
+  return (
+    <>
+      <Typography
+        variant='caption'
+        color='text.secondary'
+        sx={{
+          gridColumn: '1 / -1',
+          mt: 1,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.5,
+        }}
+      >
+        <Box component='span' sx={{ color: 'error.main' }}>
+          *
+        </Box>
+        Campos obligatorios
+      </Typography>
+
+      <Box
+        sx={{
+          gridColumn: '1 / -1',
+          display: 'flex',
+          gap: 2,
+          justifyContent: 'flex-end',
+          mt: 2,
+        }}
+      >
+        <Button
+          variant='outlined'
+          onClick={onCancel}
+          disabled={isLoading}
+          sx={{
+            borderRadius: 2,
+            textTransform: 'none',
+            fontWeight: 600,
+          }}
+        >
+          Cancelar
+        </Button>
+        <LoadingButton
+          type='submit'
+          variant='contained'
+          loading={isLoading}
+          disabled={!isValid}
+          sx={{
+            borderRadius: 2,
+            textTransform: 'none',
+            fontWeight: 600,
+          }}
+        >
+          Actualizar Proveedor
+        </LoadingButton>
+      </Box>
+    </>
+  );
+}

--- a/src/features/provider/components/EditProviderFormFields.tsx
+++ b/src/features/provider/components/EditProviderFormFields.tsx
@@ -1,0 +1,22 @@
+import { Control } from 'react-hook-form';
+import { FormTextField } from '@/shared/components/FormTextField';
+import { EditProviderFormData } from '@/features/provider/schemas/editProviderSchema';
+
+interface EditProviderFormFieldsProps {
+  control: Control<EditProviderFormData>;
+}
+
+export default function EditProviderFormFields({
+  control,
+}: EditProviderFormFieldsProps) {
+  return (
+    <>
+      <FormTextField name='cuit' control={control} label='CUIT *' type='number' />
+
+      <FormTextField name='firstName' control={control} label='Nombre *' />
+
+      <FormTextField name='address' control={control} label='Dirección' />
+      <FormTextField name='description' control={control} label='Descripción' />
+    </>
+  );
+}

--- a/src/features/provider/components/EditProviderHeader.tsx
+++ b/src/features/provider/components/EditProviderHeader.tsx
@@ -1,0 +1,38 @@
+import { Box, Typography, IconButton } from '@mui/material';
+import { ArrowBack, Edit } from '@mui/icons-material';
+
+interface EditProviderHeaderProps {
+  onBack: () => void;
+  providerName: string;
+}
+
+export default function EditProviderHeader({
+  onBack,
+  providerName,
+}: EditProviderHeaderProps) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 2,
+        mb: 3,
+      }}
+    >
+      <IconButton
+        onClick={onBack}
+        sx={{
+          bgcolor: 'background.paper',
+          border: 1,
+          borderColor: 'divider',
+        }}
+      >
+        <ArrowBack />
+      </IconButton>
+      <Edit sx={{ fontSize: 32, color: 'primary.main' }} />
+      <Typography variant='h4' fontWeight={600}>
+        Editar Proveedor: {providerName}
+      </Typography>
+    </Box>
+  );
+}

--- a/src/features/provider/components/ProviderActions.tsx
+++ b/src/features/provider/components/ProviderActions.tsx
@@ -1,0 +1,47 @@
+import { Box, IconButton } from '@mui/material';
+import { Edit, Delete } from '@mui/icons-material';
+import Tooltip from '@/shared/components/Tooltip';
+import { Provider } from '@/features/provider/types';
+
+interface ProviderActionsProps {
+  provider: Provider;
+  onEdit: (provider: Provider) => void;
+  onDelete: (provider: Provider) => void;
+}
+
+export default function ProviderActions({
+  provider,
+  onEdit,
+  onDelete,
+}: ProviderActionsProps) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 1,
+        justifyContent: 'center',
+      }}
+    >
+      <Tooltip title='Editar proveedor'>
+        <IconButton
+          size='small'
+          onClick={() => onEdit(provider)}
+          color='primary'
+          aria-label='editar proveedor'
+        >
+          <Edit fontSize='small' />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title='Eliminar proveedor'>
+        <IconButton
+          size='small'
+          onClick={() => onDelete(provider)}
+          color='error'
+          aria-label='eliminar proveedor'
+        >
+          <Delete fontSize='small' />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+}

--- a/src/features/provider/components/ProviderHeader.tsx
+++ b/src/features/provider/components/ProviderHeader.tsx
@@ -1,0 +1,47 @@
+import { Box, Typography, Button } from '@mui/material';
+import { SupervisorAccount, PersonAdd } from '@mui/icons-material';
+
+interface ProviderHeaderProps {
+  onCreateProvider?: () => void;
+}
+
+export default function ProviderHeader({
+    onCreateProvider,
+}: ProviderHeaderProps) {
+    return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        mb: 3,
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2,
+        }}
+      >
+        <SupervisorAccount sx={{ fontSize: 32, color: 'primary.main' }} />
+        <Typography variant='h4' fontWeight={600}>
+          Administrador de Proveedores
+        </Typography>
+      </Box>
+
+      <Button
+        variant='contained'
+        startIcon={<PersonAdd />}
+        onClick={onCreateProvider}
+        sx={{
+          borderRadius: 2,
+          textTransform: 'none',
+          fontWeight: 600,
+        }}
+      >
+        Crear Proveedor
+      </Button>
+    </Box>
+  );
+}

--- a/src/features/provider/components/ProviderTableRow.tsx
+++ b/src/features/provider/components/ProviderTableRow.tsx
@@ -1,0 +1,32 @@
+import { TableCell } from '@mui/material';
+import { Provider } from '@/features/provider/types';
+import { formatDNI } from '@/shared/utils/formatters';
+import ProviderActions from './ProviderActions';
+
+interface ProviderTableRowProps {
+  provider: Provider;
+  onEdit: (provider: Provider) => void;
+  onDelete: (provider: Provider) => void;
+}
+
+export default function ProviderTableRow({
+  provider,
+  onEdit,
+  onDelete,
+}: ProviderTableRowProps) {
+  return (
+    <>
+      <TableCell>{formatDNI(provider.cuit)}</TableCell>
+      <TableCell>{provider.firstName}</TableCell>
+      <TableCell>{provider.description}</TableCell>
+      <TableCell>{provider.address}</TableCell>
+      <TableCell>
+        <ProviderActions
+          provider={provider}
+          onEdit={onEdit}
+          onDelete={onDelete}
+        />
+      </TableCell>
+    </>
+  );
+}

--- a/src/features/provider/components/ProvidersTable.tsx
+++ b/src/features/provider/components/ProvidersTable.tsx
@@ -1,0 +1,71 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  CircularProgress,
+  Typography,
+} from '@mui/material';
+import { Provider } from '@/features/provider/types';
+import ProviderTableRow from './ProviderTableRow';
+
+interface ProvidersTableProps {
+  providers: Provider[];
+  isLoading: boolean;
+  onEdit: (provider: Provider) => void;
+  onDelete: (provider: Provider) => void;
+}
+
+export default function ProvidersTable({
+  providers,
+  isLoading,
+  onEdit,
+  onDelete,
+}: ProvidersTableProps) {
+  return (
+    <TableContainer>
+      <Table>
+        <TableHead>
+          <TableRow sx={{ bgcolor: 'background.default' }}>
+            <TableCell sx={{ fontWeight: 600 }}>CUIT</TableCell>
+            <TableCell sx={{ fontWeight: 600 }}>Nombre</TableCell>
+            <TableCell sx={{ fontWeight: 600 }}>Descripción</TableCell>
+            <TableCell sx={{ fontWeight: 600 }}>Dirección</TableCell>
+            <TableCell sx={{ fontWeight: 600, textAlign: 'center' }}>
+              Acciones
+            </TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {isLoading ? (
+            <TableRow>
+              <TableCell colSpan={7} sx={{ textAlign: 'center', py: 4 }}>
+                <CircularProgress />
+              </TableCell>
+            </TableRow>
+          ) : providers.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={7} sx={{ textAlign: 'center', py: 4 }}>
+                <Typography color="text.secondary">
+                  No se encontraron proveedores
+                </Typography>
+              </TableCell>
+            </TableRow>
+          ) : (
+            providers.map((provider) => (
+              <TableRow key={provider.cuit} hover>
+                <ProviderTableRow
+                  provider={provider}
+                  onEdit={onEdit}
+                  onDelete={onDelete}
+                />
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/src/features/provider/hooks/useCreateProvider.ts
+++ b/src/features/provider/hooks/useCreateProvider.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createProvider } from "@/features/provider/api/service";
+import { CreateProviderRequest, CreateProviderResponse } from "@/features/provider/types";
+import { useToast } from "@/shared/hooks/useToast";
+
+export const useCreateProvider = () => {
+
+    const queryClient = useQueryClient();
+    const { showToast } = useToast();
+
+    return useMutation<CreateProviderResponse, Error, CreateProviderRequest>({
+        mutationFn: createProvider,
+        onSuccess: (data) => {
+            queryClient.invalidateQueries({ queryKey: ['providers'] });
+            showToast(
+                `Proveedor ${data.data.firstName} creado exitosamente`,
+                'success'
+            );
+        },
+        onError: (error) => {
+            showToast(`Error al crear proveedor: ${error.message}`, 'error');
+        },
+    });
+
+}
+

--- a/src/features/provider/hooks/useDeleteProvider.ts
+++ b/src/features/provider/hooks/useDeleteProvider.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { deleteProvider } from '@/features/provider/api/service';
+import { DeleteProviderResponse } from '@/features/provider/types';
+import { useToast } from '@/shared/hooks/useToast';
+
+export const useDeleteProvider = () => {
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+
+  return useMutation<DeleteProviderResponse, Error, string>({
+    mutationFn: (providerCuit: string) => deleteProvider(Number(providerCuit)),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['providers'] });
+      showToast(
+        `Proveedor ${data.data.firstName} eliminado exitosamente`,
+        'success'
+      );
+    },
+    onError: (error) => {
+      showToast(`Error al eliminar proveedor: ${error.message}`, 'error');
+    },
+  });
+};

--- a/src/features/provider/hooks/useProviderActions.ts
+++ b/src/features/provider/hooks/useProviderActions.ts
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Provider } from '@/features/provider/types';
+import { useToast } from '@/shared/hooks/useToast';
+import { useDeleteProvider } from './useDeleteProvider';
+
+interface UseProviderActionsReturn {
+  deleteDialog: {
+    open: boolean;
+    provider: Provider | null;
+  };
+  permissionsDialog: {
+    open: boolean;
+  };
+  handleEdit: (provider: Provider) => void;
+  handleDelete: (provider: Provider) => void;
+  handleManagePermissions: () => void;
+  handleConfirmDelete: () => void;
+  handleCancelDelete: () => void;
+  handleClosePermissions: () => void;
+  isDeleting: boolean;
+}
+
+export const useProviderActions = (): UseProviderActionsReturn => {
+  const [deleteDialog, setDeleteDialog] = useState<{
+    open: boolean;
+    provider: Provider | null;
+  }>({ open: false, provider: null });
+
+  const [permissionsDialog, setPermissionsDialog] = useState<{
+    open: boolean;
+  }>({ open: false });
+
+  const { showToast } = useToast();
+  const navigate = useNavigate();
+  const deleteProviderMutation = useDeleteProvider();
+
+  const handleEdit = (provider: Provider) => {
+    if (!provider.cuit) {
+      showToast('Error: CUIT de proveedor no válido', 'error');
+      return;
+    }
+    navigate(`/entities/suppliers/edit/${provider.cuit}`);
+  };
+
+  const handleDelete = (provider: Provider) => {
+    setDeleteDialog({ open: true, provider });
+  };
+
+  const handleManagePermissions = () => {
+    setPermissionsDialog({ open: true });
+  };
+
+  const handleConfirmDelete = () => {
+    if (deleteDialog.provider) {
+      deleteProviderMutation.mutate(deleteDialog.provider.cuit.toString(), {
+        onSuccess: () => {
+          setDeleteDialog({ open: false, provider: null });
+        },
+        onError: () => {
+          setDeleteDialog({ open: false, provider: null });
+        },
+      });
+    }
+  };
+
+  const handleCancelDelete = () => {
+    setDeleteDialog({ open: false, provider: null });
+  };
+
+  const handleClosePermissions = () => {
+    setPermissionsDialog({ open: false });
+  };
+
+  return {
+    deleteDialog,
+    permissionsDialog,
+    handleEdit,
+    handleDelete,
+    handleManagePermissions,
+    handleConfirmDelete,
+    handleCancelDelete,
+    handleClosePermissions,
+    isDeleting: deleteProviderMutation.isPending,
+  };
+};

--- a/src/features/provider/hooks/useProviderByCuit.ts
+++ b/src/features/provider/hooks/useProviderByCuit.ts
@@ -1,0 +1,21 @@
+import { useProviders } from './useProviders';
+
+export const useProviderByCuit = (providerCuit: number | undefined) => {
+  const {
+    data: providersData,
+    isLoading,
+    error,
+  } = useProviders({
+    pageIndex: 1,
+    pageSize: 1000,
+  });
+
+  const provider = providersData?.data?.items?.find((p) => p.cuit === providerCuit);
+
+  return {
+    provider,
+    isLoading,
+    error,
+    isProviderFound: !!provider,
+  };
+};

--- a/src/features/provider/hooks/useProviders.ts
+++ b/src/features/provider/hooks/useProviders.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { getProviders } from "@/features/provider/api/service";
+import { GetProviderRequest } from "@/features/provider/types";
+
+export const useProviders = (params: GetProviderRequest) => {
+    return useQuery({
+        queryKey: ['providers', params.pageIndex, params.pageSize],
+        queryFn: () => getProviders(params),
+        staleTime: 5 * 60 * 1000,
+        refetchOnWindowFocus: false,
+    });
+}

--- a/src/features/provider/hooks/useUpdateProvider.ts
+++ b/src/features/provider/hooks/useUpdateProvider.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { updateProvider } from '@/features/provider/api/service';
+import { UpdateProviderRequest, UpdateProviderResponse } from '@/features/provider/types';
+import { useToast } from '@/shared/hooks/useToast';
+
+export const useUpdateProvider = () => {
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+
+  return useMutation<
+    UpdateProviderResponse,
+    Error,
+    { providerCuit: number; data: UpdateProviderRequest }
+  >({
+    mutationFn: ({ providerCuit, data }) => updateProvider(providerCuit, data),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['providers'] });
+      showToast(
+        `Proveedor ${data.data.firstName} actualizado exitosamente`,
+        'success'
+      );
+    },
+    onError: (error) => {
+      showToast(`Error al actualizar proveedor: ${error.message}`, 'error');
+    },
+  });
+};

--- a/src/features/provider/pages/CreateProviderPage.tsx
+++ b/src/features/provider/pages/CreateProviderPage.tsx
@@ -1,0 +1,74 @@
+import { useNavigate } from 'react-router-dom';
+import { Box, Paper } from '@mui/material';
+import { useFormWithSchema } from '@/shared/hooks/useFormWithSchema';
+import {
+  createProviderSchema,
+  CreateProviderFormData,
+} from '@/features/provider/schemas/createProviderSchema';
+import { useCreateProvider } from '@/features/provider/hooks/useCreateProvider';
+import CreateProviderHeader from '@/features/provider/components/CreateProviderHeader';
+import CreateProviderFormFields from '@/features/provider/components/CreateProviderFormFields';
+import CreateProviderActions from '@/features/provider/components/CreateProviderActions';
+
+export default function CreateProviderPage() {
+  const navigate = useNavigate();
+  const createProviderMutation = useCreateProvider();
+
+  const {
+    control,
+    handleSubmit,
+    formState: { isValid },
+  } = useFormWithSchema<CreateProviderFormData>({
+    schema: createProviderSchema,
+    defaultValues: {
+      cuit: undefined,
+      firstName: '',
+      address: '',
+      description: '',
+    },
+  });
+
+  const onSubmit = (data: CreateProviderFormData) => {
+    createProviderMutation.mutate(data, {
+      onSuccess: () => {
+        navigate('/entities/suppliers');
+      },
+    });
+  };
+
+  const handleBack = () => {
+    navigate('/entities/suppliers');
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <CreateProviderHeader onBack={handleBack} />
+
+      <Paper
+        sx={{
+          p: 4,
+          borderRadius: 2,
+          border: 1,
+          borderColor: 'divider',
+        }}
+      >
+        <Box
+          component='form'
+          onSubmit={handleSubmit(onSubmit)}
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
+            gap: 3,
+          }}
+        >
+          <CreateProviderFormFields control={control} />
+          <CreateProviderActions
+            onCancel={handleBack}
+            isLoading={createProviderMutation.isPending}
+            isValid={isValid}
+          />
+        </Box>
+      </Paper>
+    </Box>
+  );
+}

--- a/src/features/provider/pages/EditProviderPage.tsx
+++ b/src/features/provider/pages/EditProviderPage.tsx
@@ -1,0 +1,143 @@
+import { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Box, Paper, Typography } from '@mui/material';
+import { useFormWithSchema } from '@/shared/hooks/useFormWithSchema';
+import {
+  editProviderSchema,
+  EditProviderFormData,
+} from '@/features/provider/schemas/editProviderSchema';
+import { useUpdateProvider } from '@/features/provider/hooks/useUpdateProvider';
+import { useProviderByCuit } from '@features/provider/hooks/useProviderByCuit';
+import EditProviderHeader from '@/features/provider/components/EditProviderHeader';
+import EditProviderFormFields from '@/features/provider/components/EditProviderFormFields';
+import EditProviderActions from '@/features/provider/components/EditProviderActions';
+import { useToast } from '@/shared/hooks/useToast';
+
+export default function EditProviderPage() {
+  const navigate = useNavigate();
+  const { cuit } = useParams<{ cuit: string }>();
+  const cuitNumber = cuit ? Number(cuit) : undefined;
+  const updateProviderMutation = useUpdateProvider();
+  const { showToast } = useToast();
+
+  const { provider, isLoading, error } = useProviderByCuit(cuitNumber);
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { isValid },
+  } = useFormWithSchema<EditProviderFormData>({
+    schema: editProviderSchema,
+    defaultValues: {
+      cuit: undefined,
+      firstName: '',
+      address: '',
+      description: '',
+    },
+  });
+
+  useEffect(() => {
+    if (provider) {
+      reset({
+        cuit: provider.cuit,
+        firstName: provider.firstName,
+        address: provider.address,
+        description: provider.description
+      });
+    }
+  }, [provider, reset]);
+
+  useEffect(() => {
+    if (!cuit) {
+      showToast('CUIT del proveedor no válido', 'error');
+      navigate('/entities/suppliers');
+      return;
+    }
+
+    if (error) {
+      showToast('Error al cargar el proveedor', 'error');
+      navigate('/entities/suppliers');
+      return;
+    }
+
+    if (!isLoading && !provider && cuit) {
+      showToast(`Proveedor con CUIT "${cuit}" no encontrado`, 'error');
+      navigate('/entities/suppliers');
+    }
+  }, [cuit, provider, isLoading, error, navigate, showToast]);
+
+  const onSubmit = (data: EditProviderFormData) => {
+    if (!provider) return;
+
+    const updateData: Partial<EditProviderFormData> = {
+      cuit: data.cuit,
+      firstName: data.firstName,
+      address: data.address,
+      description: data.description
+    };
+
+    updateProviderMutation.mutate(
+      {
+        providerCuit: provider.cuit,
+        data: updateData,
+      },
+      {
+        onSuccess: () => {
+          navigate('/entities/suppliers');
+        },
+      }
+    );
+  };
+
+  const handleBack = () => {
+    navigate('/entities/suppliers');
+  };
+
+  if (!provider && isLoading) {
+    return (
+      <Box sx={{ p: 3, display: 'flex', justifyContent: 'center' }}>
+        <Typography>Cargando datos del proveedor...</Typography>
+      </Box>
+    );
+  }
+
+  if (!provider) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <EditProviderHeader
+        onBack={handleBack}
+        providerName={`${provider.firstName}`}
+      />
+
+      <Paper
+        sx={{
+          p: 4,
+          borderRadius: 2,
+          border: 1,
+          borderColor: 'divider',
+        }}
+      >
+        <Box
+          component='form'
+          onSubmit={handleSubmit(onSubmit)}
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
+            gap: 3,
+          }}
+        >
+          <EditProviderFormFields control={control} />
+          <EditProviderActions
+            onCancel={handleBack}
+            isLoading={updateProviderMutation.isPending}
+            isValid={isValid}
+          />
+        </Box>
+      </Paper>
+    </Box>
+  );
+}

--- a/src/features/provider/pages/ProviderPage.tsx
+++ b/src/features/provider/pages/ProviderPage.tsx
@@ -1,4 +1,4 @@
-import UnderConstruction from '@/shared/components/UnderConstruction';
+/* import UnderConstruction from '@/shared/components/UnderConstruction';
 
 export default function DashboardPage() {
   return (
@@ -7,5 +7,95 @@ export default function DashboardPage() {
       subtitle='El panel de proveedores estará disponible próximamente. Estamos trabajando en nuevas funcionalidades para mejorar tu experiencia.'
       size='large'
     />
+  );
+}
+ */
+
+import { Box, Paper } from '@mui/material';
+import { useToast } from '@/shared/hooks/useToast';
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router';
+import ProvidersTable from '@/features/provider/components/ProvidersTable';
+import CustomPagination from '@/shared/components/CustomPagination';
+import { useProviders } from '@/features/provider/hooks/useProviders';
+import ProviderHeader from '../components/ProviderHeader';
+import { useProviderActions } from '@/features/provider/hooks/useProviderActions';
+import ConfirmDialog from '@/shared/components/ConfirmDialog';
+
+export default function ProviderPage() {
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(5);
+  const { showToast } = useToast();
+  const navigate = useNavigate();
+
+  const { data, isLoading, error } = useProviders({
+    pageIndex: page + 1,
+    pageSize: rowsPerPage,
+  });
+
+  const {
+    deleteDialog,
+    handleEdit,
+    handleDelete,
+    handleConfirmDelete,
+    handleCancelDelete,
+    isDeleting,
+  } = useProviderActions();
+
+  useEffect(() => {
+    if (error) {
+      showToast('Error al cargar los proveedores', 'error');
+    }
+  }, [error, showToast]);
+
+  const handleChangePage = (newPage: number) => setPage(newPage);
+
+  const handleChangeRowsPerPage = (newRowsPerPage: number) => {
+    setRowsPerPage(newRowsPerPage);
+    setPage(0);
+  };
+
+  const handleCreateProvider = () => {
+    navigate('/entities/suppliers/create');
+  };
+
+  const providers = data?.data?.items || [];
+  const totalItems = data?.data?.totalItems || 0;
+  const totalPages = data?.data?.totalPages || 0;
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <ProviderHeader onCreateProvider={handleCreateProvider} />
+      <Paper sx={{ borderRadius: 2, border: 1, borderColor: 'divider' }}>
+        <ProvidersTable
+          providers={providers}
+          isLoading={isLoading}
+          onEdit={handleEdit}
+          onDelete={handleDelete}
+        />
+        <CustomPagination
+          page={page}
+          totalPages={totalPages}
+          totalItems={totalItems}
+          rowsPerPage={rowsPerPage}
+          onPageChange={handleChangePage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+        />
+      </Paper>
+      <ConfirmDialog
+        open={deleteDialog.open}
+        title='Confirmar eliminación'
+        message={
+          deleteDialog.provider
+            ? `¿Estás seguro de que deseas eliminar al proveedor ${deleteDialog.provider.firstName}? Esta acción no se puede deshacer.`
+            : ''
+        }
+        confirmText={isDeleting ? 'Eliminando...' : 'Eliminar'}
+        cancelText='Cancelar'
+        onConfirm={handleConfirmDelete}
+        onCancel={handleCancelDelete}
+        severity='error'
+      />
+    </Box>
   );
 }

--- a/src/features/provider/schemas/createProviderSchema.ts
+++ b/src/features/provider/schemas/createProviderSchema.ts
@@ -1,0 +1,24 @@
+import * as yup from 'yup';
+
+export const createProviderSchema = yup.object({
+    cuit: yup
+        .number()
+        .typeError('El CUIT debe ser un número válido')
+        .required('El CUIT es requerido')
+        .min(1000000000, 'CUIT debe tener al menos 10 dígitos')
+        .max(99999999999, 'CUIT debe tener máximo 11 dígitos'),
+    firstName: yup
+        .string()
+        .required('El nombre es requerido')
+        .min(2, 'Mínimo 2 caracteres'),
+    address: yup
+        .string()
+        .required('La dirección es requerida')
+        .min(2, 'Mínimo 2 caracteres'),
+    description: yup
+        .string()
+        .required('La descripción es requerida')
+        .min(2, 'Mínimo 2 caracteres'),
+});
+
+export type CreateProviderFormData = yup.InferType<typeof createProviderSchema>;

--- a/src/features/provider/schemas/editProviderSchema.ts
+++ b/src/features/provider/schemas/editProviderSchema.ts
@@ -1,0 +1,24 @@
+import * as yup from 'yup';
+
+export const editProviderSchema = yup.object({
+  cuit: yup
+    .number()
+    .typeError('El CUIT debe ser un número válido')
+    .required('El CUIT es requerido')
+    .min(1000000000, 'CUIT debe tener al menos 10 dígitos')
+    .max(99999999999, 'CUIT debe tener máximo 11 dígitos'),
+  firstName: yup
+    .string()
+    .required('El nombre es requerido')
+    .min(2, 'Mínimo 2 caracteres'),
+  address: yup
+    .string()
+    .required('La dirección es requerida')
+    .max(150, 'Mínimo 150 caracteres'),
+  description: yup
+    .string()
+    .required('La descripción es requerida')
+    .max(150, 'Mínimo 150 caracteres'),
+});
+
+export type EditProviderFormData = yup.InferType<typeof editProviderSchema>;

--- a/src/features/provider/types/index.ts
+++ b/src/features/provider/types/index.ts
@@ -1,0 +1,61 @@
+export interface Provider {
+    cuit: number;
+    firstName: string;
+    address: string;
+    description: string;
+}
+
+export interface GetProviderRequest {
+  pageIndex: number;
+  pageSize: number;
+}
+
+export interface CreateProviderRequest {
+  cuit: number;
+  firstName: string;
+  address: string;
+  description: string;
+}
+
+export interface UpdateProviderRequest {
+  cuit?: number;
+  firstName?: string;
+  lastName?: string;
+  description?: string;
+}
+
+export interface PaginationData<T> {
+  items: T[];
+  pageIndex: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+  hasPreviousPage: boolean;
+  hasNextPage: boolean;
+}
+
+export interface ApiResponse<T> {
+  success: boolean;
+  message: string;
+  data: T;
+  status: number;
+}
+
+export interface ApiError {
+  statusCode: number;
+  message: string;
+  path: string;
+  details: string;
+}
+
+export interface GetProvidersResponse extends ApiResponse<PaginationData<Provider>> {}
+
+export interface CreateProviderResponse extends ApiResponse<Provider> {
+  error?: ApiError;
+}
+
+export interface UpdateProviderResponse extends ApiResponse<Provider> {
+  error?: ApiError;
+}
+
+export interface DeleteProviderResponse extends ApiResponse<Provider> {}


### PR DESCRIPTION
# Descripción
Se implementa el módulo de gestión de proveedores con operaciones CRUD, incluyendo:
- Página de listado de proveedores con paginación.
- Formulario para crear y editar proveedores.
- Validaciones de datos en el frontend.
- Integración con la API para persistencia.

# Cambios principales
- src/features/provider/pages/ProviderPage.tsx
- src/features/provider/components/ProviderForm.tsx
- src/features/provider/api/service.ts

# Notas adicionales
- Se añadieron hooks personalizados para manejo de estado y validaciones.